### PR TITLE
Move installation of requirements_dev from travis to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 - pip install tox
 - pip install python-coveralls
 - pip install codecov
-- pip install -r requirements_dev.txt
 script:
 - tox
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ commands = py.test --cov=./
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt
+deps =
+     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
Without this, running `tox` locally is dependent on the global environment having the deps installed. This is ... less than optimal.